### PR TITLE
Add support for overriding the default locale currency

### DIFF
--- a/lib/cldr/messages/format/interpreter.ex
+++ b/lib/cldr/messages/format/interpreter.ex
@@ -67,7 +67,14 @@ defmodule Cldr.Message.Interpreter do
     [Cldr.Number.to_string!(number, options)]
   end
 
-  def format_list({number, :number, :currency}, _args, options) do
+  def format_list({number, :number, :currency}, args, options) do
+    options =
+      if currency = Keyword.get(args, :currency) do
+        Keyword.put(options, :currency, currency)
+      else
+        options
+      end
+
     options = Keyword.put(options, :format, :currency)
     [Cldr.Number.to_string!(number, options)]
   end

--- a/test/cldr_messages_test.exs
+++ b/test/cldr_messages_test.exs
@@ -241,4 +241,20 @@ defmodule Cldr_Messages_Test do
       end
     end
   end
+
+  test "default currency is used for the given locale" do
+    template = "Your order total is {amount, number, currency}."
+    args = [amount: 199.50]
+    options = [locale: "en"]
+
+    assert Cldr.Message.format(template, args, options) == {:ok, "Your order total is $199.50."}
+  end
+
+  test "allow overriding the default locale currency" do
+    template = "Your order total is {amount, number, currency}."
+    args = [amount: 199.50, currency: "MXN"]
+    options = [locale: "en"]
+
+    assert Cldr.Message.format(template, args, options) == {:ok, "Your order total is MX$199.50."}
+  end
 end


### PR DESCRIPTION
When formatting currencies the currency symbol is based on the locale in use. It would be useful if we could override this default by specify which currency to use when formatting.

For example, say I was building a book selling website in the US and it allowed the user to purchase a book from Mexico. I would now be able to format a string in US English with the Mexican currency displayed.

By default the current format function would display the USD currency symbol giving an incorrect representation of the purchase amount.

