### PR TITLE
Add gettext as a required dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,13 +47,13 @@ defmodule Cldr.Messages.MixProject do
       {:nimble_parsec, "~> 0.5 or ~> 1.0"},
       {:ex_cldr_numbers, "~> 2.23"},
       {:jason, "~> 1.1"},
+      {:gettext, "~> 0.19"},
       {:ex_cldr_dates_times, "~> 2.10", optional: true},
       {:ex_money, "~> 5.7", optional: true},
       {:ex_cldr_units, "~> 3.8", optional: true},
       {:ex_cldr_lists, "~> 2.9", optional: true},
       {:dialyxir, "~> 1.0", optional: true, only: [:dev], runtime: false},
-      {:ex_doc, "~> 0.20", optional: true, runtime: false},
-      {:gettext, "~> 0.19", optional: true}
+      {:ex_doc, "~> 0.20", optional: true, runtime: false}
     ]
   end
 


### PR DESCRIPTION
This fixes compilation of Mix projects which have no explicit dependency on gettext.

I guess the dependency is no longer optional since gettext has been added to the list of compilers.