### PR TITLE
Interpolate Gettext strings with missing bindings as far as is possible

### DIFF
--- a/lib/cldr/messages/backend.ex
+++ b/lib/cldr/messages/backend.ex
@@ -88,8 +88,9 @@ defmodule Cldr.Message.Backend do
       {:ok, iolist, _bound, [] = _unbound} ->
         {:ok, :erlang.iolist_to_binary(iolist)}
 
-      {:error, _iolist, _bound, unbound} ->
-        {:missing_bindings, message, unbound}
+      {:error, iolist, _bound, unbound} ->
+        {:missing_bindings, iolist |> prepare_print_literals() |> Cldr.Message.Print.to_string(),
+         unbound}
     end
   end
 
@@ -99,10 +100,17 @@ defmodule Cldr.Message.Backend do
       {:ok, iolist, _bound, [] = _unbound} ->
         {:ok, :erlang.iolist_to_binary(iolist)}
 
-      {:error, _iolist, _bound, unbound} ->
-        {:missing_bindings, parsed, unbound}
+      {:error, iolist, _bound, unbound} ->
+        {:missing_bindings, iolist |> prepare_print_literals() |> Cldr.Message.Print.to_string(),
+         unbound}
     end
   end
+
+  defp prepare_print_literals(iolist), do: Enum.map(iolist, &prepare_print_literal/1)
+
+  defp prepare_print_literal(part)
+  defp prepare_print_literal(literal) when is_binary(literal), do: {:literal, literal}
+  defp prepare_print_literal(other), do: other
 
   # Return a keyword list of static bindings, if they
   # are all static. Otherwise return nil.

--- a/test/gettext_interpolation_test.exs
+++ b/test/gettext_interpolation_test.exs
@@ -23,8 +23,8 @@ defmodule Cldr.Messages.GettextInterpolationtest do
              gettext("runtime {one, number, currency}", %{one: {1, currency: :MXP}})
 
     assert capture_log(fn ->
-             assert "runtime {one, number, currency}" ==
-                      gettext("runtime {one, number, currency}", %{})
+             assert "runtime {one, number, currency} two" ==
+                      gettext("runtime {one, number, currency} {two}", %{two: "two"})
            end) =~ "missing Gettext bindings: [\"one\"]"
   end
 
@@ -46,6 +46,11 @@ defmodule Cldr.Messages.GettextInterpolationtest do
 
     assert gettext(~m"runtime {one, number, currency}", %{one: {1, currency: :MXP}}) ==
              gettext(~m"runtime {one,   number,   currency}", %{one: {1, currency: :MXP}})
+
+    assert capture_log(fn ->
+             assert "runtime {one, number, currency} two" ==
+                      gettext(~m"runtime {one, number, currency} {two}", %{two: "two"})
+           end) =~ "missing Gettext bindings: [\"one\"]"
   end
 
   test "number formatting in gettext finds the CLDR backend" do


### PR DESCRIPTION
## Default Implementation

I checked the `gettext` default implementation, which also interpolates as far as possible.

## Use case

I'm currently working on an application where a user supplies values for a default message. If the user provides all parameters, the message is completely interpolated. If there are missing bindings, the message should be returned with the `{binding}` placeholders for all missing entries.

The following code also hides the error (only for this specific use case):

```elixir
defmodule Acme.Gettext do
  # ...

  @impl Gettext.Backend
  def handle_missing_bindings(error, incomplete)

  # Ignore Missing bindings in Template Strings (expected to be missing sometimes)
  def handle_missing_bindings(%Gettext.MissingBindingsError{domain: "template"}, incomplete),
    do: incomplete

  def handle_missing_bindings(error, incomplete), do: super(error, incomplete)
end
```

