### PR TITLE
Fix not extracting variable bindings from simple_format arg

### DIFF
--- a/lib/cldr/messages/messages.ex
+++ b/lib/cldr/messages/messages.ex
@@ -440,6 +440,7 @@ defmodule Cldr.Message do
     Enum.reduce(message, [], fn
       {:named_arg, arg}, acc -> [arg | acc]
       {:pos_arg, arg}, acc -> [arg | acc]
+      {:simple_format, {_, arg}, _, _}, acc -> [arg | acc]
       {:select, {_, arg}, selectors}, acc -> [arg, bindings(selectors) | acc]
       {:plural, {_, arg}, _, selectors}, acc -> [arg, bindings(selectors) | acc]
       {:select_ordinal, {_, arg}, _, selectors}, acc -> [arg, bindings(selectors) | acc]

--- a/test/cldr_messages_test.exs
+++ b/test/cldr_messages_test.exs
@@ -274,7 +274,12 @@ defmodule Cldr_Messages_Test do
              ["gender_of_host", "num_guests", "host", "guest"]
   end
 
-  test "that postional arguments can be prohitbited" do
+  test "Extract variable bindings from simple_format messages" do
+    assert Cldr.Message.bindings("Watched {percentage_watched, number, percent} of {video_name}") ==
+             ["video_name", "percentage_watched"]
+  end
+
+  test "that positional arguments can be prohibited" do
     assert Cldr.Message.format("Can you see {0}", ["me"], allow_positional_args: false) ==
              {:error,
               {Cldr.Message.PositionalArgsNotPermitted, "Positional arguments are not permitted"}}


### PR DESCRIPTION
**Summary:**
Adds logic to extract variable bindings from simple_format arg in a message

**Behavior before fix:**
```
pry()> Cldr.Message.bindings("Das Video wurde am {watched_at, date, short} um {watched_time, time, short} angesehen")
=> []
```

**After fix:**
```
pry()> Cldr.Message.bindings("Das Video wurde am {watched_at, date, short} um {watched_time, time, short} angesehen")
=> ["watched_at", "watched_time"]
```